### PR TITLE
Fix error passing null to setForwardedIp.

### DIFF
--- a/Model/LoginRepository.php
+++ b/Model/LoginRepository.php
@@ -72,6 +72,7 @@ class LoginRepository implements LoginRepositoryInterface
      */
     protected function initLoginActivity(): Login
     {
+        /** @var Login $login */
         $login = $this->loginFactory->create();
 
         $user = $this->getUser();
@@ -81,7 +82,7 @@ class LoginRepository implements LoginRepositoryInterface
         }
 
         $login->setRemoteIp($this->processor->getRemoteAddress()->getRemoteAddress());
-        $login->setForwardedIp($this->processor->getRequest()->getServer('HTTP_X_FORWARDED_FOR'));
+        $login->setForwardedIp((string)$this->processor->getRequest()->getServer('HTTP_X_FORWARDED_FOR'));
         $login->setUserAgent($this->processor->getHandler()->getHeader()->getHttpUserAgent());
 
         return $login;


### PR DESCRIPTION
Add type casting for forwarded IP in LoginRepository List of changes:
- Added type casting to ensure `HTTP_X_FORWARDED_FOR` server value is explicitly cast to a string in `LoginRepository`.
- Added type hinting comment for the `$login` variable for improved code clarity and maintainability.