### PR TITLE
Fix inconsistent handling of store ID in AdminActivityLog Processor

### DIFF
--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -414,7 +414,12 @@ class Processor
             return $model->getScopeId();
         }
         if (isset($data['store_id'])) {
-            return $model->getStoreId();
+            $storeId = $model->getStoreId();
+            if (is_array($storeId)) {
+                $storeId = reset($storeId);
+            }
+
+            return (int)$storeId;
         }
         return $this->storeManager->getStore()->getId();
     }


### PR DESCRIPTION
List of changes:
- Updated `Processor::getScopeId()` method to handle cases where `$model->getStoreId()` returns an array.
- Ensured proper type casting of `$storeId` to integer for consistent processing.