### PR TITLE
fix: Config cannot be saved if itemName is null

### DIFF
--- a/Model/Handler/PostDispatch.php
+++ b/Model/Handler/PostDispatch.php
@@ -120,7 +120,7 @@ class PostDispatch
 
                 $log = clone $activity;
                 $log->setItemName(
-                    $model->getData($processor->getConfig()->getActivityModuleItemField($config['module']))
+                    $model->getData($processor->getConfig()->getActivityModuleItemField($config['module'])) ?? ''
                 );
                 $log->setItemUrl($processor->getEditUrl($model));
 

--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -362,7 +362,7 @@ class Processor
         $activity->setItemName(
             $model->getData(
                 $this->config->getActivityModuleItemField($this->eventConfig['module'])
-            )
+            ) ?? ''
         );
         $activity->setItemUrl($this->getEditUrl($model));
 


### PR DESCRIPTION
If you save the configuration, the itemName is null. Due to the strict string argument type for Activity::setItemName, an error occurs and the configuration is not saved. 