### PR TITLE
Add missing semicolon

### DIFF
--- a/Api/ActivityConfigInterface.php
+++ b/Api/ActivityConfigInterface.php
@@ -93,5 +93,5 @@ interface ActivityConfigInterface
      *
      * @return int Number of days
      */
-    public function getClearLogDays(): int
+    public function getClearLogDays(): int;
 }


### PR DESCRIPTION
This caused this error:
```
ParseError: syntax error, unexpected token "}", expecting ";" or "{" in /var/www/html/vendor/mage-os/module-admin-activity-log/Api/ActivityConfigInterface.php:97
```