### PR TITLE
Fix system config change logging for correct old/new values

### DIFF
--- a/Model/Activity/SystemConfig.php
+++ b/Model/Activity/SystemConfig.php
@@ -15,6 +15,7 @@ namespace MageOS\AdminActivityLog\Model\Activity;
 
 use Magento\Config\Model\Config\Structure;
 use Magento\Config\Model\Config\Structure\Element\Section;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\ValueFactory;
 use Magento\Framework\DataObject;
 use MageOS\AdminActivityLog\Api\Activity\ModelInterface;
@@ -30,7 +31,8 @@ class SystemConfig implements ModelInterface
     public function __construct(
         protected readonly DataObject $dataObject,
         protected readonly ValueFactory $valueFactory,
-        private readonly Structure $configStructure
+        private readonly Structure $configStructure,
+        private readonly ScopeConfigInterface $scopeConfig
     ) {
     }
 
@@ -116,33 +118,47 @@ class SystemConfig implements ModelInterface
     {
         $logData = [];
 
-        $path = $this->getPath($model);
+        $section = $this->getPath($model);
         $model->setConfig('System Configuration');
-        $model->setId($path);
+        $model->setId($section);
 
+        $fullPath = (string)$model->getData('path');
+        $parts = explode('/', $fullPath);
+        if (count($parts) < 3) {
+            return $logData;
+        }
+
+        [, $group, $field] = $parts;
+
+        $newRaw = $model->getData('value') ?? '';
         $oldGroups = $model->getOrigData() ?? [];
-        $newGroups = $model->getGroups() ?? [];
+        $oldRaw = $oldGroups[$group]['fields'][$field]['value']
+            ?? $this->scopeConfig->getValue($fullPath)
+            ?? '';
 
-        foreach ($newGroups as $group => $groupData) {
-            if (empty($groupData['fields'])) {
-                continue;
-            }
-            foreach ($groupData['fields'] as $field => $fieldData) {
-                $newRaw = $fieldData['value'] ?? '';
-                $oldRaw = $oldGroups[$group]['fields'][$field]['value'] ?? '';
-                $newValue = is_array($newRaw) ? implode(',', $newRaw) : (string)$newRaw;
-                $oldValue = is_array($oldRaw) ? implode(',', $oldRaw) : (string)$oldRaw;
-                if ($newValue === $oldValue) {
-                    continue;
-                }
-                $fieldPath = implode('/', [$path, $group, $field]);
-                $logData[$fieldPath] = [
-                    'old_value' => $oldValue,
-                    'new_value' => $newValue,
-                ];
-            }
+        $newValue = $this->flattenValue($newRaw);
+        $oldValue = $this->flattenValue($oldRaw);
+
+        if ($newValue !== $oldValue) {
+            $logData[$fullPath] = [
+                'old_value' => $oldValue,
+                'new_value' => $newValue,
+            ];
         }
 
         return $logData;
+    }
+
+    private function flattenValue(mixed $value): string
+    {
+        if (!is_array($value)) {
+            return (string)$value;
+        }
+
+        if (array_is_list($value) && !array_filter($value, 'is_array')) {
+            return implode(',', $value);
+        }
+
+        return (string)json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 }

--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -96,12 +96,6 @@ class Processor
      */
     public function validate($model): bool
     {
-        if ($this->activityConfig->isWildCardModel($model)) {
-            if (!empty($this->activityLogs)) {
-                return false;
-            }
-        }
-
         if ($this->eventConfig) {
             $usedModel = (array)$this->config->getEventModel($this->eventConfig['module']);
             $pathConst = $this->config->getActivityModuleConstant($this->eventConfig['module']);
@@ -182,10 +176,17 @@ class Processor
         if ($this->validate($model)) {
             $logData = $this->handler->modelEdit($model, $this->getMethod());
             if (!empty($logData)) {
-                $activity = $this->initActivity($model);
-                $activity->setActionType($label);
-
-                $this->addLog($activity, $logData, $model);
+                if ($this->activityConfig->isWildCardModel($model) && !empty($this->activityLogs)) {
+                    $lastIndex = array_key_last($this->activityLogs);
+                    $this->activityLogs[$lastIndex][ActivityLog::class] = array_merge(
+                        $this->activityLogs[$lastIndex][ActivityLog::class],
+                        $logData
+                    );
+                } else {
+                    $activity = $this->initActivity($model);
+                    $activity->setActionType($label);
+                    $this->addLog($activity, $logData, $model);
+                }
             }
         }
 

--- a/Observer/SaveAfter.php
+++ b/Observer/SaveAfter.php
@@ -35,8 +35,9 @@ class SaveAfter extends AbstractActivityObserver
         if ($object->getCheckIfIsNew()) {
             if ($this->processor->getInitAction() === self::SYSTEM_CONFIG) {
                 $this->processor->modelEditAfter($object);
+            } else {
+                $this->processor->modelAddAfter($object);
             }
-            $this->processor->modelAddAfter($object);
 
             // Sync origData to current data so subsequent edit checks find no changes
             foreach ($object->getData() as $key => $value) {

--- a/Observer/SaveBefore.php
+++ b/Observer/SaveBefore.php
@@ -35,15 +35,12 @@ class SaveBefore extends AbstractActivityObserver
             $object->setCheckIfIsNew(true);
         } else {
             $object->setCheckIfIsNew(false);
-            if ($this->processor->validate($object)) {
-                $origData = $object->getOrigData();
-                if (!empty($origData)) {
-                    return;
-                }
-                $data = $this->activityRepository->getOldData($object);
-                foreach ($data->getData() as $key => $value) {
-                    $object->setOrigData($key, $value);
-                }
+        }
+
+        if ($this->processor->validate($object)) {
+            $data = $this->activityRepository->getOldData($object);
+            foreach ($data->getData() as $key => $value) {
+                $object->setOrigData($key, $value);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Rewrites system config change logging to process each config path individually rather than iterating grouped form data, fixing incorrect old/new value capture
- Moves the wildcard-model deduplication check from `validate()` into `modelEditAfter()` so multiple config saves within one request merge their log entries instead of silently dropping them
- Adjusts `SaveBefore` to always populate origData (not only for existing records), and `SaveAfter` to skip `modelAddAfter` when handling system config edits
- Adds `ScopeConfigInterface` fallback for old values when origData is missing

Fixes incorrect old/new values logged for system configuration changes.

## Test plan

- [ ] Save a system config section and verify the activity log records correct old and new values for each changed field
- [ ] Save a section with no actual changes and verify no false-positive log entries are created
- [ ] Save config with multiselect or dynamic-row fields and verify nested array values are logged correctly (flattenValue from main)
- [ ] Save multiple fields in one section save and verify all changed fields appear in a single merged log entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)