### PR TITLE
fix: Observer was breaking because id was null as old data didn't exist

### DIFF
--- a/Model/ActivityRepository.php
+++ b/Model/ActivityRepository.php
@@ -101,7 +101,12 @@ class ActivityRepository implements ActivityRepositoryInterface
             return false;
         }
 
-        $data = $this->modelResolver->loadModel($className, $model->getId());
+        $entityId = $model->getId();
+        if ($entityId === null) {
+            return false;
+        }
+
+        $data = $this->modelResolver->loadModel($className, $entityId);
         if ($data->getId()) {
             return $data;
         }


### PR DESCRIPTION
### Summary
Added an early null check in getOldData() before calling loadModel(). If the model has no ID it is a new record with no existing data to compare against, so we return false immediately — consistent with the other early-return cases in the same method.

This fixes issue https://github.com/mage-os-lab/module-admin-activity-log/issues/27