### PR TITLE
Fix conflicts with other AfterSave observers which check if an entity is new

### DIFF
--- a/Observer/SaveAfter.php
+++ b/Observer/SaveAfter.php
@@ -40,11 +40,6 @@ class SaveAfter extends AbstractActivityObserver
             } else {
                 $this->processor->modelAddAfter($object);
             }
-
-            // Sync origData to current data so subsequent edit checks find no changes
-            foreach ($object->getData() as $key => $value) {
-                $object->setOrigData($key, $value);
-            }
         } elseif ($this->processor->validate($object)) {
             if ($this->processor->getEventConfig('action') === self::ACTION_MASSCANCEL) {
                 $this->processor->modelDeleteAfter($object);

--- a/Test/Unit/Observer/SaveAfterTest.php
+++ b/Test/Unit/Observer/SaveAfterTest.php
@@ -119,16 +119,24 @@ class SaveAfterTest extends TestCase
         $this->subject->execute($this->createObserverWithObject($object));
     }
 
-    public function testSyncsOrigDataForNewObjects(): void
+    public function testDoesNotPolluteOrigDataForNewObjects(): void
     {
-        $object = $this->createObjectMockForNew(['name' => 'Product', 'sku' => 'ABC']);
+        $object = $this->createObjectMockForNew([
+            'entity_id' => 42,
+            'name' => 'Product',
+            'sku' => 'ABC',
+        ]);
 
         $this->processor->method('getInitAction')->willReturn('catalog_product_save');
 
         $this->subject->execute($this->createObserverWithObject($object));
 
-        $this->assertSame('Product', $object->getOrigData('name'));
-        $this->assertSame('ABC', $object->getOrigData('sku'));
+        // orig_data must stay empty for a freshly inserted entity so downstream
+        // <event_prefix>_save_commit_after observers can detect new entities via
+        // empty(getOrigData('entity_id')) (the standard Magento idiom).
+        $this->assertNull($object->getOrigData('entity_id'));
+        $this->assertNull($object->getOrigData('name'));
+        $this->assertNull($object->getOrigData('sku'));
     }
 
     public function testCallsModelEditAfterForExistingValidObject(): void


### PR DESCRIPTION
Drop redundant `orig_data` resync in `SaveAfter` that breaks downstream observers, i.e. those in `mage-os/mageos-common-async-events`

### Problem

  `SaveAfter::process()`, in the new-entity branch, calls:
  
  ```php
  // Sync origData to current data so subsequent edit checks find no changes
  foreach ($object->getData() as $key => $value) {
      $object->setOrigData($key, $value);
  }
  ```

  after `modelAddAfter()`. Because `SaveBefore` flags every newly-saved tracked model with `setCheckIfIsNew(true)`, this loop runs for every newly-created tracked entity — credit memos, invoices, shipments, 
  comments, statuses, etc.

  That violates Magento's `orig_data` contract. `orig_data` is the public "values as they exist in the database for the previous state of this row" — a long-standing Magento idiom. Setting it equal to current 
  data on a freshly inserted row corrupts the standard pattern downstream observers use to detect newly-created entities:

  ```php
  private function isCreditmemoCreated(Creditmemo $creditmemo): bool
  {
      return empty($creditmemo->getOrigData('entity_id'));
  }
  ```

  After this module runs on `model_save_after`, `getOrigData('entity_id')` is populated with the just-generated id, so any `<event_prefix>_save_commit_after` observer using that check skips its work.

  ### Concrete impact

  `MageOS\CommonAsyncEvents\Observer\SalesOrderCreditmemoSaveAfterObserver` (from `mage-os/mageos-common-async-events`) no longer publishes `sales.creditmemo.created` when an admin creates a credit memo,
  because its `isCreditmemoCreated()` check inverts. The async event integration silently stops working.

  We discovered this in the `mage-os/mageos-common-async-events` observer `\MageOS\CommonAsyncEvents\Observer\SalesOrderCreditmemoSaveAfterObserver` that uses the same idiom on `sales_order_creditmemo_save_commit_after`. Other observers in the wider ecosystem are likely affected the same way.

  ### Reproduction

  1. Install this module and any module with an observer on `sales_order_creditmemo_save_commit_after` that detects new credit memos via `empty($creditmemo->getOrigData('entity_id'))` (e.g. `mage-os/mageos-common-async-events`).
  2. Create a credit memo in the admin.
  3. Observe that `sales.creditmemo.created` is not published.

  ### Why removing the foreach is safe

  The foreach exists to handle the case where the same model instance is saved a second time in the same request, so the `modelEditAfter` of that second save sees no field changes. That guard is unnecessary
  because **`SaveBefore` already re-seeds `orig_data` from the database on every save**:

  ```php
  // SaveBefore::process()
  if ($this->processor->validate($object)) {
      $data = $this->activityRepository->getOldData($object);
      if (!$data) {
          return;
      }
      foreach ($data->getData() as $key => $value) {
          $object->setOrigData($key, $value);
      }
  }
  ```
  
  So at the start of the hypothetical second save the foreach was protecting against, `SaveBefore` overwrites whatever the previous `SaveAfter` wrote anyway — from a more authoritative source (the database).
  The foreach is computing a value that gets discarded.

  For the activity log's own write paths, nothing changes:
  
  - `modelAddAfter` (new-entity path) → `FieldTracker::getAddData()` reads `$model->getData()` only. It never touches `origData`.
  - `modelEditAfter` (edit path) → `FieldTracker::getEditData()` reads `origData`, but it has been populated by `SaveBefore` on the current save.